### PR TITLE
BUG: Copy images from ringBuffer when GetImage is called

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ project( UltrasoundIntersonApps CXX )
 option( Build_Spectroscopy ON )
 
 #Required packages and libraries
-FIND_PACKAGE( IntersonArraySDKCxx REQUIRED )
+find_package( IntersonArraySDKCxx REQUIRED )
+
+find_package( PlusLib REQUIRED )
+include( ${PlusLib_USE_FILE} )
 
 find_package( ITK REQUIRED )
 

--- a/IntersonArrayDeviceRF.hxx
+++ b/IntersonArrayDeviceRF.hxx
@@ -141,6 +141,9 @@ public:
       {
       Stop();
       success = hwControls.SendHighVoltage( voltage, voltage );
+      if(success){
+         highVoltage = voltage;
+      }
       Start();
       }
     return success;

--- a/IntersonArrayDeviceRF.hxx
+++ b/IntersonArrayDeviceRF.hxx
@@ -341,7 +341,15 @@ public:
 
   ImageType::Pointer GetBModeImage( int ringBufferIndex )
     {
-    return bModeRingBuffer[ ringBufferIndex ];
+    ImageType::Pointer image = CreateBModeImage();
+    const ImageType::RegionType & largestRegion =
+      image->GetLargestPossibleRegion();
+    const ImageType::SizeType imageSize = largestRegion.GetSize();
+    PixelType *imageBuffer = image->GetPixelContainer()->GetBufferPointer();
+    PixelType *ringImageBuffer = bModeRingBuffer[ringBufferIndex]->GetPixelContainer()->GetBufferPointer();
+    std::memcpy( imageBuffer, ringImageBuffer,
+                 imageSize[ 0 ] * imageSize[ 1 ] * sizeof( PixelType ) );
+    return image; 
     };
 
   ImageType::Pointer GetBModeImageAbsolute( int absoluteIndex )
@@ -361,7 +369,16 @@ public:
 
   RFImageType::Pointer GetRFImage( int ringBufferIndex )
     {
-    return rfRingBuffer[ ringBufferIndex ];
+    
+    RFImageType::Pointer image = CreateRFImage();
+    const RFImageType::RegionType & largestRegion =
+      image->GetLargestPossibleRegion();
+    const RFImageType::SizeType imageSize = largestRegion.GetSize();
+    RFPixelType *imageBuffer = image->GetPixelContainer()->GetBufferPointer();
+    RFPixelType *ringImageBuffer = rfRingBuffer[ringBufferIndex]->GetPixelContainer()->GetBufferPointer();
+    std::memcpy( imageBuffer, ringImageBuffer,
+                 imageSize[ 0 ] * imageSize[ 1 ] * sizeof( RFPixelType ) );
+    return image; 
     };
 
   RFImageType::Pointer GetRFImageAbsolute( int absoluteIndex )
@@ -389,7 +406,6 @@ public:
     ImageType::Pointer image = bModeRingBuffer[ index ];
     const ImageType::RegionType & largestRegion =
       image->GetLargestPossibleRegion();
-
     const ImageType::SizeType imageSize = largestRegion.GetSize();
 
     PixelType *imageBuffer = image->GetPixelContainer()->GetBufferPointer();
@@ -477,28 +493,53 @@ private:
   HWControlsType hwControls;
   ContainerType container;
 
+  ImageType::Pointer CreateBModeImage()
+    {
+    ImageType::Pointer image = ImageType::New();
+
+    ImageType::IndexType imageIndex;
+    imageIndex.Fill( 0 );
+
+    ImageType::SizeType imageSize;
+    imageSize[ 0 ] = ContainerType::MAX_SAMPLES;
+    imageSize[ 1 ] = height;
+
+    ImageType::RegionType imageRegion;
+    imageRegion.SetIndex( imageIndex );
+    imageRegion.SetSize( imageSize );
+
+    image->SetRegions( imageRegion );
+    image->Allocate();
+
+    return image;
+    }
+
   void InitalizeBModeRingBuffer()
     {
     for( unsigned int i = 0; i < bModeRingBuffer.size(); i++ )
       {
-      ImageType::Pointer image = ImageType::New();
-
-      ImageType::IndexType imageIndex;
-      imageIndex.Fill( 0 );
-
-      ImageType::SizeType imageSize;
-      imageSize[ 0 ] = ContainerType::MAX_SAMPLES;
-      imageSize[ 1 ] = height;
-
-      ImageType::RegionType imageRegion;
-      imageRegion.SetIndex( imageIndex );
-      imageRegion.SetSize( imageSize );
-
-      image->SetRegions( imageRegion );
-      image->Allocate();
-
-      bModeRingBuffer[ i ] = image;
+      bModeRingBuffer[ i ] = CreateBModeImage();
       }
+    }
+
+  RFImageType::Pointer CreateRFImage()
+    {
+    RFImageType::Pointer image = RFImageType::New();
+
+    RFImageType::IndexType imageIndex;
+    imageIndex.Fill( 0 );
+
+    RFImageType::SizeType imageSize;
+    imageSize[ 0 ] = ContainerType::MAX_RFSAMPLES;
+    imageSize[ 1 ] = height;
+
+    RFImageType::RegionType imageRegion;
+    imageRegion.SetIndex( imageIndex );
+    imageRegion.SetSize( imageSize );
+
+    image->SetRegions( imageRegion );
+    image->Allocate();
+    return image;
     }
 
   void InitalizeRFRingBuffer()
@@ -509,23 +550,8 @@ private:
 
     for( unsigned int i = 0; i < rfRingBuffer.size(); i++ )
       {
-      RFImageType::Pointer image = RFImageType::New();
 
-      RFImageType::IndexType imageIndex;
-      imageIndex.Fill( 0 );
-
-      RFImageType::SizeType imageSize;
-      imageSize[ 0 ] = ContainerType::MAX_RFSAMPLES;
-      imageSize[ 1 ] = height;
-
-      RFImageType::RegionType imageRegion;
-      imageRegion.SetIndex( imageIndex );
-      imageRegion.SetSize( imageSize );
-
-      image->SetRegions( imageRegion );
-      image->Allocate();
-
-      rfRingBuffer[ i ] = image;
+      rfRingBuffer[ i ] = CreateRFImage();
       }
     }
 

--- a/SpectroscopyUI.cxx
+++ b/SpectroscopyUI.cxx
@@ -358,7 +358,7 @@ void SpectroscopyUI::RecordRF()
         std::cout << "Failed to set voltage: " << v << std::endl;
         continue;
         }
-      Sleep(500);
+      Sleep(100);
       int lastIndex = intersonDevice.GetCurrentRFIndex();
       int index = intersonDevice.GetCurrentRFIndex();
       //for(int nIm =0; nIm<3; nIm++){

--- a/SpectroscopyUI.cxx
+++ b/SpectroscopyUI.cxx
@@ -358,13 +358,16 @@ void SpectroscopyUI::RecordRF()
         std::cout << "Failed to set voltage: " << v << std::endl;
         continue;
         }
+      Sleep(500);
       int lastIndex = intersonDevice.GetCurrentRFIndex();
       int index = intersonDevice.GetCurrentRFIndex();
+      //for(int nIm =0; nIm<3; nIm++){
       while( index == lastIndex )
         {
         Sleep( 10 );
         index = intersonDevice.GetCurrentRFIndex();
         }
+      lastIndex = index;
       images.push_back( intersonDevice.GetRFImage( intersonDevice.GetCurrentRFIndex() ) );
 
       time_t now = time( 0 );
@@ -382,6 +385,7 @@ void SpectroscopyUI::RecordRF()
       ftext << std::setw( 10 ) << std::fixed;
       ftext << frequencies[ i ] << "_" << date << ".nrrd";
       imageNames.push_back( ftext.str() );
+      //}
       }
     }
 


### PR DESCRIPTION
Images where not copied form ring buffer when GetImage is called in IntersonArrayDeviceRF. If images are not immediately used it may get overwritten as the ring buffers are filled.